### PR TITLE
Add rendering of HTML in table responses

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -142,7 +142,6 @@ class App extends Component {
   setComponents(components) {
     // is array and only contains strings, if it has elements
     // TODO: Edit string check back once we move on from the MVP
-    console.log(components);
     if (
       !Array.isArray(components) ||
       (Array.isArray(components) &&

--- a/src/components/TableMessage/TableMessage.jsx
+++ b/src/components/TableMessage/TableMessage.jsx
@@ -39,7 +39,7 @@ export default class TableMessage extends Component {
       this.props.messageObject.tableData.results.bindings.map((dataSet) => (
         <tr>
           {this.props.messageObject.tableData.head.vars.map((header) => (
-            <td>{dataSet[header].value}</td>
+            <td dangerouslySetInnerHTML={{ __html: dataSet[header].value }} />
           ))}
         </tr>
       ));

--- a/src/helpers/getTexts.js
+++ b/src/helpers/getTexts.js
@@ -19,7 +19,6 @@ function changeLanguage(newLanguage = "de") {
   if (currentLanguage === newLanguage) return;
   currentLanguage = newLanguage;
   try {
-    console.log(currentLanguage, newLanguage);
     texts = require(`../texts/${currentLanguage}/texts.json`);
     listeners.forEach((listener) => listener.callback());
   } catch(errorMessage) {

--- a/src/services/__mocks__/chatbot.service.js
+++ b/src/services/__mocks__/chatbot.service.js
@@ -4,7 +4,6 @@
 const chatBotService = jest.createMockFromModule("../chatbot.service.js");
 
 chatBotService.postQuery = jest.fn((question) => {
-  console.log("Hi");
   return Promise.resolve({});
 });
 


### PR DESCRIPTION
Previously, the response was displayed as raw text, but now it will
render all HTML that's passed to it. Note that this increases the
risk of XSS, like all uses of innerHTML.